### PR TITLE
[Feat/detail screen] DetailScreen 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -112,4 +112,7 @@ dependencies {
     // Kotlin Serialization
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.1")
     implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0")
+
+    // WebView
+    implementation("com.google.accompanist:accompanist-webview:0.24.13-rc")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,6 +34,7 @@ android {
         buildConfigField("String", "NAVER_OEPNAPI_BASE_URL", properties.getProperty("naver_openapi_base_url"))
         buildConfigField("String", "NAVER_OEPNAPI_CLIENT_ID", properties.getProperty("naver_openapi_client_id"))
         buildConfigField("String", "NAVER_OEPNAPI_CLIENT_SECRET", properties.getProperty("naver_openapi_client_secret"))
+        buildConfigField("String", "NAVER_SEARCH_BASE_URL", properties.getProperty("naver_search_base_url"))
         buildConfigField("String", "DOEAT_BASE_URL", properties.getProperty("doeat_base_url"))
 
         manifestPlaceholders["KAKAO_SIGNIN_NATIVE_KEY"] = KAKAO_SIGNIN_NATIVE_KEY

--- a/app/src/main/java/com/mbj/doeat/data/remote/model/FindUserRequest.kt
+++ b/app/src/main/java/com/mbj/doeat/data/remote/model/FindUserRequest.kt
@@ -1,0 +1,9 @@
+package com.mbj.doeat.data.remote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FindUserRequest(
+    @SerialName("kakaoUserId") val kakaoUserId: Long,
+)

--- a/app/src/main/java/com/mbj/doeat/data/remote/model/Party.kt
+++ b/app/src/main/java/com/mbj/doeat/data/remote/model/Party.kt
@@ -1,0 +1,17 @@
+package com.mbj.doeat.data.remote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Party(
+    @SerialName("postId") val postId: Long,
+    @SerialName("userId") val userId: Long,
+    @SerialName("restaurantName") val restaurantName: String,
+    @SerialName("category") val category: String,
+    @SerialName("restaurantLocation") val restaurantLocation: String,
+    @SerialName("recruitmentLimit") val recruitmentLimit: Int,
+    @SerialName("currentNumberPeople") val currentNumberPeople: Int,
+    @SerialName("detail") val detail: String,
+    @SerialName("link") val link: String? = null
+)

--- a/app/src/main/java/com/mbj/doeat/data/remote/model/PartyPostRequest.kt
+++ b/app/src/main/java/com/mbj/doeat/data/remote/model/PartyPostRequest.kt
@@ -1,0 +1,24 @@
+package com.mbj.doeat.data.remote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PartyPostRequest(
+    @SerialName("userId")
+    val userId: Long,
+    @SerialName("restaurantName")
+    val restaurantName: String,
+    @SerialName("category")
+    val category: String,
+    @SerialName("restaurantLocation")
+    val restaurantLocation: String,
+    @SerialName("recruitmentLimit")
+    val recruitmentLimit: Int,
+    @SerialName("currentNumberPeople")
+    val currentNumberPeople: Int,
+    @SerialName("detail")
+    val detail: String,
+    @SerialName("link")
+    val link: String
+)

--- a/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/DefaultDBApi.kt
+++ b/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/DefaultDBApi.kt
@@ -1,5 +1,6 @@
 package com.mbj.doeat.data.remote.network.api.default_db
 
+import com.mbj.doeat.data.remote.model.FindUserRequest
 import com.mbj.doeat.data.remote.model.LoginRequest
 import com.mbj.doeat.data.remote.model.LoginResponse
 import com.mbj.doeat.data.remote.model.Party
@@ -26,4 +27,10 @@ interface DefaultDBApi {
         onComplete: () -> Unit,
         onError: (message: String?) -> Unit
     ): Flow<ApiResponse<Party>>
+
+    fun findUser(
+        findUserRequest: FindUserRequest,
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit
+    ): Flow<ApiResponse<LoginResponse>>
 }

--- a/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/DefaultDBApi.kt
+++ b/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/DefaultDBApi.kt
@@ -2,6 +2,7 @@ package com.mbj.doeat.data.remote.network.api.default_db
 
 import com.mbj.doeat.data.remote.model.LoginRequest
 import com.mbj.doeat.data.remote.model.LoginResponse
+import com.mbj.doeat.data.remote.model.Party
 import com.mbj.doeat.data.remote.network.adapter.ApiResponse
 import kotlinx.coroutines.flow.Flow
 
@@ -12,4 +13,10 @@ interface DefaultDBApi {
         onComplete: () -> Unit,
         onError: (message: String?) -> Unit
     ): Flow<ApiResponse<LoginResponse>>
+
+    fun getPartiesByLocation(
+        restaurantLocation: String,
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit
+    ): Flow<ApiResponse<List<Party>>>
 }

--- a/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/DefaultDBApi.kt
+++ b/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/DefaultDBApi.kt
@@ -3,6 +3,7 @@ package com.mbj.doeat.data.remote.network.api.default_db
 import com.mbj.doeat.data.remote.model.LoginRequest
 import com.mbj.doeat.data.remote.model.LoginResponse
 import com.mbj.doeat.data.remote.model.Party
+import com.mbj.doeat.data.remote.model.PartyPostRequest
 import com.mbj.doeat.data.remote.network.adapter.ApiResponse
 import kotlinx.coroutines.flow.Flow
 
@@ -19,4 +20,10 @@ interface DefaultDBApi {
         onComplete: () -> Unit,
         onError: (message: String?) -> Unit
     ): Flow<ApiResponse<List<Party>>>
+
+    fun postParty(
+        partyPostRequest: PartyPostRequest,
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit
+    ): Flow<ApiResponse<Party>>
 }

--- a/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/repository/DefaultDBDataSource.kt
+++ b/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/repository/DefaultDBDataSource.kt
@@ -3,6 +3,7 @@ package com.mbj.doeat.data.remote.network.api.default_db.repository
 import com.mbj.doeat.data.remote.model.LoginRequest
 import com.mbj.doeat.data.remote.model.LoginResponse
 import com.mbj.doeat.data.remote.model.Party
+import com.mbj.doeat.data.remote.model.PartyPostRequest
 import com.mbj.doeat.data.remote.network.adapter.ApiResponse
 import com.mbj.doeat.data.remote.network.adapter.onError
 import com.mbj.doeat.data.remote.network.adapter.onException
@@ -50,6 +51,28 @@ class DefaultDBDataSource @Inject constructor(
     ): Flow<ApiResponse<List<Party>>> = flow {
         try {
             val response = defaultDBService.getPartiesByLocation(restaurantLocation)
+            response.onSuccess {
+                emit(response)
+            }.onError { code, message ->
+                onError("code: $code, message: $message")
+            }.onException {
+                onError(it.message)
+            }
+        } catch (e: Exception) {
+            onError(e.message)
+        }
+    }.onCompletion {
+        onComplete()
+    }.flowOn(defaultDispatcher)
+
+    override fun postParty(
+        partyPostRequest: PartyPostRequest,
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit
+    ): Flow<ApiResponse<Party>> = flow {
+        try {
+            val response = defaultDBService.postParty(partyPostRequest)
+
             response.onSuccess {
                 emit(response)
             }.onError { code, message ->

--- a/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/repository/DefaultDBDataSource.kt
+++ b/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/repository/DefaultDBDataSource.kt
@@ -2,6 +2,7 @@ package com.mbj.doeat.data.remote.network.api.default_db.repository
 
 import com.mbj.doeat.data.remote.model.LoginRequest
 import com.mbj.doeat.data.remote.model.LoginResponse
+import com.mbj.doeat.data.remote.model.Party
 import com.mbj.doeat.data.remote.network.adapter.ApiResponse
 import com.mbj.doeat.data.remote.network.adapter.onError
 import com.mbj.doeat.data.remote.network.adapter.onException
@@ -28,6 +29,27 @@ class DefaultDBDataSource @Inject constructor(
         try {
             val response = defaultDBService.login(loginRequest)
 
+            response.onSuccess {
+                emit(response)
+            }.onError { code, message ->
+                onError("code: $code, message: $message")
+            }.onException {
+                onError(it.message)
+            }
+        } catch (e: Exception) {
+            onError(e.message)
+        }
+    }.onCompletion {
+        onComplete()
+    }.flowOn(defaultDispatcher)
+
+    override fun getPartiesByLocation(
+        restaurantLocation: String,
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit
+    ): Flow<ApiResponse<List<Party>>> = flow {
+        try {
+            val response = defaultDBService.getPartiesByLocation(restaurantLocation)
             response.onSuccess {
                 emit(response)
             }.onError { code, message ->

--- a/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/repository/DefaultDBDataSource.kt
+++ b/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/repository/DefaultDBDataSource.kt
@@ -1,5 +1,6 @@
 package com.mbj.doeat.data.remote.network.api.default_db.repository
 
+import com.mbj.doeat.data.remote.model.FindUserRequest
 import com.mbj.doeat.data.remote.model.LoginRequest
 import com.mbj.doeat.data.remote.model.LoginResponse
 import com.mbj.doeat.data.remote.model.Party
@@ -72,6 +73,28 @@ class DefaultDBDataSource @Inject constructor(
     ): Flow<ApiResponse<Party>> = flow {
         try {
             val response = defaultDBService.postParty(partyPostRequest)
+
+            response.onSuccess {
+                emit(response)
+            }.onError { code, message ->
+                onError("code: $code, message: $message")
+            }.onException {
+                onError(it.message)
+            }
+        } catch (e: Exception) {
+            onError(e.message)
+        }
+    }.onCompletion {
+        onComplete()
+    }.flowOn(defaultDispatcher)
+
+    override fun findUser(
+        findUserRequest: FindUserRequest,
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit
+    ): Flow<ApiResponse<LoginResponse>> = flow {
+        try {
+            val response = defaultDBService.findUser(findUserRequest)
 
             response.onSuccess {
                 emit(response)

--- a/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/repository/DefaultDBRepository.kt
+++ b/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/repository/DefaultDBRepository.kt
@@ -2,6 +2,7 @@ package com.mbj.doeat.data.remote.network.api.default_db.repository
 
 import com.mbj.doeat.data.remote.model.LoginRequest
 import com.mbj.doeat.data.remote.model.LoginResponse
+import com.mbj.doeat.data.remote.model.Party
 import com.mbj.doeat.data.remote.network.adapter.ApiResponse
 import com.mbj.doeat.data.remote.network.api.default_db.DefaultDBApi
 import kotlinx.coroutines.flow.Flow
@@ -18,6 +19,18 @@ class DefaultDBRepository @Inject constructor(
     ): Flow<ApiResponse<LoginResponse>> {
         return defaultDBDataSource.signIn(
             loginRequest,
+            onComplete = onComplete,
+            onError = onError
+        )
+    }
+
+    override fun getPartiesByLocation(
+        restaurantLocation: String,
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit
+    ): Flow<ApiResponse<List<Party>>> {
+        return defaultDBDataSource.getPartiesByLocation(
+            restaurantLocation,
             onComplete = onComplete,
             onError = onError
         )

--- a/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/repository/DefaultDBRepository.kt
+++ b/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/repository/DefaultDBRepository.kt
@@ -1,5 +1,6 @@
 package com.mbj.doeat.data.remote.network.api.default_db.repository
 
+import com.mbj.doeat.data.remote.model.FindUserRequest
 import com.mbj.doeat.data.remote.model.LoginRequest
 import com.mbj.doeat.data.remote.model.LoginResponse
 import com.mbj.doeat.data.remote.model.Party
@@ -44,6 +45,18 @@ class DefaultDBRepository @Inject constructor(
     ): Flow<ApiResponse<Party>> {
         return defaultDBDataSource.postParty(
             partyPostRequest,
+            onComplete = onComplete,
+            onError = onError
+        )
+    }
+
+    override fun findUser(
+        findUserRequest: FindUserRequest,
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit
+    ): Flow<ApiResponse<LoginResponse>> {
+        return defaultDBDataSource.findUser(
+            findUserRequest,
             onComplete = onComplete,
             onError = onError
         )

--- a/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/repository/DefaultDBRepository.kt
+++ b/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/repository/DefaultDBRepository.kt
@@ -3,6 +3,7 @@ package com.mbj.doeat.data.remote.network.api.default_db.repository
 import com.mbj.doeat.data.remote.model.LoginRequest
 import com.mbj.doeat.data.remote.model.LoginResponse
 import com.mbj.doeat.data.remote.model.Party
+import com.mbj.doeat.data.remote.model.PartyPostRequest
 import com.mbj.doeat.data.remote.network.adapter.ApiResponse
 import com.mbj.doeat.data.remote.network.api.default_db.DefaultDBApi
 import kotlinx.coroutines.flow.Flow
@@ -31,6 +32,18 @@ class DefaultDBRepository @Inject constructor(
     ): Flow<ApiResponse<List<Party>>> {
         return defaultDBDataSource.getPartiesByLocation(
             restaurantLocation,
+            onComplete = onComplete,
+            onError = onError
+        )
+    }
+
+    override fun postParty(
+        partyPostRequest: PartyPostRequest,
+        onComplete: () -> Unit,
+        onError: (message: String?) -> Unit
+    ): Flow<ApiResponse<Party>> {
+        return defaultDBDataSource.postParty(
+            partyPostRequest,
             onComplete = onComplete,
             onError = onError
         )

--- a/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/service/DefaultDBService.kt
+++ b/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/service/DefaultDBService.kt
@@ -3,6 +3,7 @@ package com.mbj.doeat.data.remote.network.api.default_db.service
 import com.mbj.doeat.data.remote.model.LoginRequest
 import com.mbj.doeat.data.remote.model.LoginResponse
 import com.mbj.doeat.data.remote.model.Party
+import com.mbj.doeat.data.remote.model.PartyPostRequest
 import com.mbj.doeat.data.remote.network.adapter.ApiResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -16,4 +17,7 @@ interface DefaultDBService {
 
     @GET("party/restaurant/{restaurantLocation}")
     suspend fun getPartiesByLocation(@Path("restaurantLocation") restaurantLocation: String): ApiResponse<List<Party>>
+
+    @POST("party/post")
+    suspend fun postParty(@Body request: PartyPostRequest): ApiResponse<Party>
 }

--- a/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/service/DefaultDBService.kt
+++ b/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/service/DefaultDBService.kt
@@ -2,12 +2,18 @@ package com.mbj.doeat.data.remote.network.api.default_db.service
 
 import com.mbj.doeat.data.remote.model.LoginRequest
 import com.mbj.doeat.data.remote.model.LoginResponse
+import com.mbj.doeat.data.remote.model.Party
 import com.mbj.doeat.data.remote.network.adapter.ApiResponse
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Path
 
 interface DefaultDBService {
 
     @POST("user")
     suspend fun login(@Body request: LoginRequest): ApiResponse<LoginResponse>
+
+    @GET("party/restaurant/{restaurantLocation}")
+    suspend fun getPartiesByLocation(@Path("restaurantLocation") restaurantLocation: String): ApiResponse<List<Party>>
 }

--- a/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/service/DefaultDBService.kt
+++ b/app/src/main/java/com/mbj/doeat/data/remote/network/api/default_db/service/DefaultDBService.kt
@@ -1,5 +1,6 @@
 package com.mbj.doeat.data.remote.network.api.default_db.service
 
+import com.mbj.doeat.data.remote.model.FindUserRequest
 import com.mbj.doeat.data.remote.model.LoginRequest
 import com.mbj.doeat.data.remote.model.LoginResponse
 import com.mbj.doeat.data.remote.model.Party
@@ -20,4 +21,7 @@ interface DefaultDBService {
 
     @POST("party/post")
     suspend fun postParty(@Body request: PartyPostRequest): ApiResponse<Party>
+
+    @POST("user/find")
+    suspend fun findUser(@Body findUserRequest: FindUserRequest): ApiResponse<LoginResponse>
 }

--- a/app/src/main/java/com/mbj/doeat/ui/component/LadingView.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/component/LadingView.kt
@@ -1,0 +1,29 @@
+package com.mbj.doeat.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import com.mbj.doeat.ui.theme.Black700
+
+@Composable
+fun LoadingView(
+    isLoading: Boolean,
+    boxColor: Color = Black700,
+    circularProgressIndicatorColor: Color = Color.White
+) {
+    if (isLoading) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(boxColor),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator(color = circularProgressIndicatorColor)
+        }
+    }
+}

--- a/app/src/main/java/com/mbj/doeat/ui/component/LongRectangleButtonWithParams.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/component/LongRectangleButtonWithParams.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.Text
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 
@@ -55,7 +56,8 @@ fun LongRectangleButtonWithParams(
             text = text,
             color = contentColor,
             style = textStyle,
-            fontSize = fontSize
+            fontSize = fontSize,
+            fontWeight = FontWeight.Bold
         )
     }
 }

--- a/app/src/main/java/com/mbj/doeat/ui/component/LongRectangleButtonWithParams.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/component/LongRectangleButtonWithParams.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
 
 
 @Composable
@@ -32,10 +33,10 @@ fun LongRectangleButtonWithParams(
     backgroundColor: Color = Yellow700,
     contentColor: Color = Color.Black,
     textStyle: TextStyle = MaterialTheme.typography.button,
+    fontSize: TextUnit = TextUnit.Unspecified,
     onClick: () -> Unit
 ) {
     Box(
-
         modifier = Modifier
             .padding(padding)
             .then(if (useFillMaxWidth) Modifier.fillMaxWidth() else Modifier.width(width))
@@ -54,6 +55,7 @@ fun LongRectangleButtonWithParams(
             text = text,
             color = contentColor,
             style = textStyle,
+            fontSize = fontSize
         )
     }
 }

--- a/app/src/main/java/com/mbj/doeat/ui/component/ToastMessage.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/component/ToastMessage.kt
@@ -14,16 +14,16 @@ import kotlinx.coroutines.launch
 @Composable
 fun ToastMessage(
     modifier: Modifier = Modifier,
+    showToast: Boolean,
     showMessage: Boolean,
     message: String,
-    clickCount: Int,
     duration: SnackbarDuration = SnackbarDuration.Short
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
 
     val scope = rememberCoroutineScope()
 
-    LaunchedEffect(clickCount) {
+    LaunchedEffect(showToast) {
         if (showMessage) {
             scope.launch {
                 snackbarHostState.showSnackbar(

--- a/app/src/main/java/com/mbj/doeat/ui/component/YesNoDialog.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/component/YesNoDialog.kt
@@ -1,0 +1,121 @@
+package com.mbj.doeat.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.mbj.doeat.ui.theme.Beige50
+import com.mbj.doeat.ui.theme.DoEatTheme
+import com.mbj.doeat.ui.theme.Pink500
+import com.mbj.doeat.ui.theme.Remon400
+
+
+@Composable
+fun YesNoDialog(
+    showDialog: Boolean,
+    onYesClick: () -> Unit,
+    onNoClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    title: String,
+    message: String,
+    confirmButtonMessage: String,
+    dismissButtonMessage: String,
+) {
+
+    if (showDialog) {
+        AlertDialog(
+            onDismissRequest = { onNoClick() },
+            modifier = modifier,
+            title = {
+                Text(
+                    text = title,
+                    color = Color.Black,
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.Bold
+                )
+            },
+            text = {
+                Text(
+                    text = message,
+                    color = Color.Black,
+                    fontSize = 16.sp,
+                )
+            },
+            buttons = {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 12.dp),
+                    horizontalArrangement = Arrangement.SpaceAround
+                ) {
+                    TextButton(
+                        onClick = {
+                            onYesClick()
+                        },
+                        modifier = Modifier
+                            .padding(8.dp)
+                            .fillMaxWidth(0.4f)
+                            .height(50.dp)
+                            .background(Remon400, shape = RoundedCornerShape(16.dp))
+                    ) {
+                        Text(
+                            text = confirmButtonMessage,
+                            color = Color.Black,
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+
+                    TextButton(
+                        onClick = {
+                                  onNoClick()
+                        },
+                        modifier = Modifier
+                            .padding(8.dp)
+                            .fillMaxWidth(0.4f)
+                            .height(50.dp)
+                            .background(Pink500, shape = RoundedCornerShape(16.dp))
+                    ) {
+                        Text(
+                            text = dismissButtonMessage,
+                            color = Color.Black,
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+            },
+            shape = RoundedCornerShape(16.dp),
+            backgroundColor = Beige50
+        )
+    }
+}
+
+@Preview
+@Composable
+fun YesNoDialogPreview() {
+    DoEatTheme {
+        YesNoDialog(
+            showDialog = true,
+            onYesClick = {},
+            onNoClick = {},
+            title = "파티를 모집하시겠습니까?",
+            message = "파티가 등록됩니다.",
+            confirmButtonMessage = "등록",
+            dismissButtonMessage = "취소"
+        )
+    }
+}

--- a/app/src/main/java/com/mbj/doeat/ui/graph/DetailNavGraph.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/graph/DetailNavGraph.kt
@@ -1,0 +1,48 @@
+package com.mbj.doeat.ui.graph
+
+import androidx.navigation.NamedNavArgument
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.mbj.doeat.data.remote.model.SearchItem
+import com.mbj.doeat.ui.screen.home.detail.DetailScreen
+import com.mbj.doeat.util.SerializationUtils
+
+fun NavGraphBuilder.detailsNavGraph(navController: NavHostController) {
+    composable(
+        route = DetailScreen.Detail.routeWithArgName(),
+        arguments = DetailScreen.Detail.arguments
+    ) { navBackStackEntry ->
+        val searchItem = DetailScreen.Detail.findArgument(navBackStackEntry)
+        DetailScreen(
+            searchItem = searchItem!!,
+            navController = navController,
+            onClick = { }
+        )
+    }
+}
+
+sealed class DetailScreen(val route: String, val argName: String) {
+    object Detail : DetailScreen(route = "DETAIL", argName = "searchItem")
+
+    val arguments: List<NamedNavArgument> = listOf(
+        navArgument(argName) { type = NavType.StringType }
+    )
+
+    fun routeWithArgName(): String {
+        return "$route/{$argName}"
+    }
+
+    fun navigateWithArg(argValue: SearchItem?): String {
+        val arg = SerializationUtils.toJson(argValue)
+        return "$route/$arg"
+    }
+
+    fun findArgument(navBackStackEntry: NavBackStackEntry): SearchItem? {
+        val searchItemString = navBackStackEntry.arguments?.getString(argName)
+        return SerializationUtils.fromJson<SearchItem>(searchItemString)
+    }
+}

--- a/app/src/main/java/com/mbj/doeat/ui/graph/HomeNavGraph.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/graph/HomeNavGraph.kt
@@ -53,6 +53,7 @@ fun HomeNavGraph(
                 onClick = { }
             )
         }
+        detailsNavGraph(navController = navController)
     }
 }
 

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
@@ -22,6 +22,7 @@ import com.google.accompanist.web.AccompanistWebViewClient
 import com.google.accompanist.web.WebView
 import com.google.accompanist.web.rememberWebViewNavigator
 import com.google.accompanist.web.rememberWebViewState
+import com.mbj.doeat.BuildConfig
 import com.mbj.doeat.data.remote.model.SearchItem
 import com.mbj.doeat.ui.screen.home.detail.viewmodel.DetailViewModel
 import com.mbj.doeat.util.UrlUtils
@@ -38,7 +39,7 @@ fun DetailScreen(searchItem: SearchItem, navController: NavHostController, onCli
     val webChromeClient = AccompanistWebChromeClient()
     val webViewNavigator = rememberWebViewNavigator()
     val url = if (searchItemState?.link == "") {
-        "https://search.naver.com/search.naver?query=${searchItemState?.title}"
+        "${BuildConfig.NAVER_SEARCH_BASE_URL}search.naver?query=${searchItemState?.title}"
     } else {
         UrlUtils.decodeUrl(searchItemState?.link ?: "")
     }

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.BottomSheetState
 import androidx.compose.material.BottomSheetValue
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldDefaults
@@ -67,6 +68,7 @@ import com.mbj.doeat.ui.screen.home.detail.viewmodel.DetailViewModel
 import com.mbj.doeat.ui.theme.Beige100
 import com.mbj.doeat.ui.theme.Gray200
 import com.mbj.doeat.ui.theme.Remon400
+import com.mbj.doeat.ui.theme.Yellow700
 import com.mbj.doeat.util.UrlUtils
 
 @OptIn(ExperimentalMaterialApi::class)
@@ -182,28 +184,49 @@ fun DetailContent(
                 .padding(8.dp),
             horizontalArrangement = Arrangement.Start
         ) {
-            BackButton(webViewNavigator, navController)
+            BackButton(navController)
         }
 
-        WebView(
-            state = webViewState,
-            navigator = webViewNavigator,
-            client = webViewClient,
-            chromeClient = webChromeClient,
-            onCreated = { webView ->
-                with(webView) {
-                    settings.run {
-                        javaScriptEnabled = true
-                        domStorageEnabled = true
-                        javaScriptCanOpenWindowsAutomatically = false
-                    }
-                }
-            },
+        Box(
             modifier = Modifier
                 .fillMaxHeight(0.5f)
                 .fillMaxWidth()
                 .padding(start = 4.dp, end = 4.dp)
-        )
+        ) {
+            WebView(
+                state = webViewState,
+                navigator = webViewNavigator,
+                client = webViewClient,
+                chromeClient = webChromeClient,
+                onCreated = { webView ->
+                    with(webView) {
+                        settings.run {
+                            javaScriptEnabled = true
+                            domStorageEnabled = true
+                            javaScriptCanOpenWindowsAutomatically = false
+                        }
+                    }
+                },
+                modifier = Modifier.fillMaxSize()
+            )
+
+            IconButton(
+                onClick = {
+                    if (webViewNavigator.canGoBack) {
+                        webViewNavigator.navigateBack()
+                    }
+                },
+                modifier = Modifier
+                    .padding(16.dp)
+                    .align(Alignment.TopStart)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.ArrowBack,
+                    contentDescription = "뒤로 가기",
+                    tint = Yellow700
+                )
+            }
+        }
 
         Text(
             text = "현재 개설된 파티",
@@ -227,16 +250,12 @@ fun DetailContent(
 }
 
 @Composable
-fun BackButton(webViewNavigator: WebViewNavigator, navController: NavHostController) {
+fun BackButton(navController: NavHostController) {
     Icon(
         imageVector = Icons.Default.ArrowBack,
         contentDescription = "뒤로 가기",
         modifier = Modifier.clickable {
-            if (webViewNavigator.canGoBack) {
-                webViewNavigator.navigateBack()
-            } else {
-                navController.popBackStack()
-            }
+            navController.popBackStack()
         }
     )
 }

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
@@ -28,6 +30,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.google.accompanist.web.AccompanistWebChromeClient
 import com.google.accompanist.web.AccompanistWebViewClient
@@ -46,7 +49,7 @@ import com.mbj.doeat.util.UrlUtils
 @Composable
 fun DetailScreen(searchItem: SearchItem, navController: NavHostController, onClick: () -> Unit) {
 
-    val viewModel = DetailViewModel()
+    val viewModel: DetailViewModel = hiltViewModel()
 
     viewModel.updateSearchItem(searchItem)
     val searchItemState by viewModel.searchItem.collectAsState()
@@ -63,6 +66,8 @@ fun DetailScreen(searchItem: SearchItem, navController: NavHostController, onCli
         url = url,
         additionalHttpHeaders = emptyMap()
     )
+
+    val partyListState by viewModel.partyList.collectAsState()
 
     Column(
         modifier = Modifier
@@ -106,121 +111,142 @@ fun DetailScreen(searchItem: SearchItem, navController: NavHostController, onCli
                 .fillMaxWidth()
                 .padding(8.dp)
         )
-    }
 
-    @Composable
-    fun PartyItem(
-        party: Party,
-        onJoinClick: (Party) -> Unit
-    ) {
-        Column(
+        Text(
+            text = "현재 개설된 파티",
+            fontWeight = FontWeight.Bold,
+            fontSize = 28.sp,
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(8.dp)
-                .background(Beige100, shape = RoundedCornerShape(12.dp))
-                .border(1.dp, Color.Gray, shape = RoundedCornerShape(12.dp))
+                .align(Alignment.CenterHorizontally)
+                .padding(top = 10.dp, bottom = 10.dp)
+        )
+
+        LazyColumn(
+            modifier = Modifier.padding(bottom = 80.dp)
         ) {
-            Column(
-                modifier = Modifier.padding(16.dp)
-            ) {
-                Row(
-                    horizontalArrangement = Arrangement.Center
-                ) {
-                    Text(
-                        text = party.restaurantName,
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 18.sp,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        color = Color.Black,
-                        modifier = Modifier
-                            .fillMaxWidth(0.6f)
-                    )
-
-                    Spacer(modifier = Modifier.width(8.dp))
-
-                    Text(
-                        text = party.category,
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 12.sp,
-                        color = Color.Gray,
-                        modifier = Modifier.align(Alignment.CenterVertically),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
-
-                Text(
-                    text = party.restaurantLocation,
-                    fontSize = 11.sp,
-                    color = Color.Black,
-                    modifier = Modifier.padding(top = 4.dp)
-
-                )
-
-                Text(
-                    text = party.detail,
-                    fontSize = 14.sp,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                    color = Color.Gray,
-                    modifier = Modifier.padding(top = 8.dp)
-                )
-
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 20.dp)
-                        .clickable {
-                            onJoinClick(party)
-                        },
-                    horizontalArrangement = Arrangement.Center,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = "${party.currentNumberPeople} / ${party.recruitmentLimit}",
-                        fontSize = 22.sp,
-                        color = Color.Black,
-                        fontWeight = FontWeight.Bold,
-                        modifier = Modifier
-                    )
-
-                    Spacer(modifier = Modifier.width(40.dp))
-
-                    Text(
-                        text = "참가하기",
-                        fontWeight = FontWeight.Bold,
-                        color = Color.Black,
-                        modifier = Modifier
-                            .background(Remon400, shape = RoundedCornerShape(4.dp))
-                            .padding(4.dp)
-                            .clickable {
-                                /**
-                                 * 채팅방 참가하기 TODO
-                                 */
-                                onJoinClick
-                            }
-                    )
-                }
+            items(
+                items = partyListState,
+                key = { party -> party.postId }
+            ) { party ->
+                PartyItem(party = party, onJoinClick = {})
             }
         }
     }
+}
 
-    @Preview
-    @Composable
-    fun PartyItemPreview() {
-        DoEatTheme {
-            val dummyParty = Party(
-                postId = 11,
-                userId = 4,
-                restaurantName = "마노디셰프1231231212231231313131313123",
-                restaurantLocation = "서울특별시 송파구 송파대로 570 타워 730 B1",
-                recruitmentLimit = 10,
-                currentNumberPeople = 5,
-                detail = "This is a party description. This is a party description. This is a party description. This is a party description. This is a party description. This is a party description.",
-                link = "",
-                category = "음식점>이탈리아 음식 12313123131312312"
+@Composable
+fun PartyItem(
+    party: Party,
+    onJoinClick: (Party) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+            .background(Beige100, shape = RoundedCornerShape(12.dp))
+            .border(1.dp, Color.Gray, shape = RoundedCornerShape(12.dp))
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Text(
+                    text = party.restaurantName,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 18.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = Color.Black,
+                    modifier = Modifier
+                        .fillMaxWidth(0.6f)
+                )
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                Text(
+                    text = party.category,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 12.sp,
+                    color = Color.Gray,
+                    modifier = Modifier.align(Alignment.CenterVertically),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+
+            Text(
+                text = party.restaurantLocation,
+                fontSize = 11.sp,
+                color = Color.Black,
+                modifier = Modifier.padding(top = 4.dp)
+
             )
-            PartyItem(party = dummyParty, onJoinClick = {})
+
+            Text(
+                text = party.detail,
+                fontSize = 14.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                color = Color.Gray,
+                modifier = Modifier.padding(top = 8.dp)
+            )
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 20.dp)
+                    .clickable {
+                        onJoinClick(party)
+                    },
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "${party.currentNumberPeople} / ${party.recruitmentLimit}",
+                    fontSize = 22.sp,
+                    color = Color.Black,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier
+                )
+
+                Spacer(modifier = Modifier.width(40.dp))
+
+                Text(
+                    text = "참가하기",
+                    fontWeight = FontWeight.Bold,
+                    color = Color.Black,
+                    modifier = Modifier
+                        .background(Remon400, shape = RoundedCornerShape(4.dp))
+                        .padding(4.dp)
+                        .clickable {
+                            /**
+                             * 채팅방 참가하기 TODO
+                             */
+                            onJoinClick
+                        }
+                )
+            }
         }
     }
+}
+
+@Preview
+@Composable
+fun PartyItemPreview() {
+    DoEatTheme {
+        val dummyParty = Party(
+            postId = 11,
+            userId = 4,
+            restaurantName = "마노디셰프1231231212231231313131313123",
+            restaurantLocation = "서울특별시 송파구 송파대로 570 타워 730 B1",
+            recruitmentLimit = 10,
+            currentNumberPeople = 5,
+            detail = "This is a party description. This is a party description. This is a party description. This is a party description. This is a party description. This is a party description.",
+            link = "",
+            category = "음식점>이탈리아 음식 12313123131312312"
+        )
+        PartyItem(party = dummyParty, onJoinClick = {})
+    }
+}

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
@@ -1,29 +1,68 @@
 package com.mbj.doeat.ui.screen.home.detail
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
+import com.google.accompanist.web.AccompanistWebChromeClient
+import com.google.accompanist.web.AccompanistWebViewClient
+import com.google.accompanist.web.WebView
+import com.google.accompanist.web.rememberWebViewNavigator
+import com.google.accompanist.web.rememberWebViewState
 import com.mbj.doeat.data.remote.model.SearchItem
+import com.mbj.doeat.ui.screen.home.detail.viewmodel.DetailViewModel
+import com.mbj.doeat.util.UrlUtils
 
 @Composable
 fun DetailScreen(searchItem: SearchItem, navController: NavHostController, onClick: () -> Unit) {
 
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
+    val viewModel = DetailViewModel()
+    viewModel.updateSearchItem(searchItem)
+
+    val searchItemState by viewModel.searchItem.collectAsState()
+
+    val webViewClient = AccompanistWebViewClient()
+    val webChromeClient = AccompanistWebChromeClient()
+    val webViewNavigator = rememberWebViewNavigator()
+    val url = if (searchItemState?.link == "") {
+        "https://search.naver.com/search.naver?query=${searchItemState?.title}"
+    } else {
+        UrlUtils.decodeUrl(searchItemState?.link ?: "")
+    }
+    val webViewState = rememberWebViewState(
+        url = url,
+        additionalHttpHeaders = emptyMap()
+    )
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
     ) {
-        Text(
-            modifier = Modifier.clickable { onClick() },
-            text = searchItem.roadAddress,
-            fontSize = MaterialTheme.typography.h3.fontSize,
-            fontWeight = FontWeight.Bold
+        WebView(
+            state = webViewState,
+            navigator = webViewNavigator,
+            client = webViewClient,
+            chromeClient = webChromeClient,
+            onCreated = { webView ->
+                with(webView) {
+                    settings.run {
+                        javaScriptEnabled = true
+                        domStorageEnabled = true
+                        javaScriptCanOpenWindowsAutomatically = false
+                    }
+                }
+            },
+            modifier = Modifier
+                .fillMaxHeight(0.6f)
+                .fillMaxWidth()
+                .padding(8.dp)
         )
     }
 }

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
@@ -1,10 +1,16 @@
 package com.mbj.doeat.ui.screen.home.detail
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -24,8 +30,8 @@ import com.mbj.doeat.util.UrlUtils
 fun DetailScreen(searchItem: SearchItem, navController: NavHostController, onClick: () -> Unit) {
 
     val viewModel = DetailViewModel()
-    viewModel.updateSearchItem(searchItem)
 
+    viewModel.updateSearchItem(searchItem)
     val searchItemState by viewModel.searchItem.collectAsState()
 
     val webViewClient = AccompanistWebViewClient()
@@ -45,6 +51,25 @@ fun DetailScreen(searchItem: SearchItem, navController: NavHostController, onCli
         modifier = Modifier
             .fillMaxSize()
     ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
+            horizontalArrangement = Arrangement.Start
+        ) {
+            Icon(
+                imageVector = Icons.Default.ArrowBack,
+                contentDescription = "뒤로 가기",
+                modifier = Modifier.clickable {
+                    if (webViewNavigator.canGoBack) {
+                        webViewNavigator.navigateBack()
+                    } else {
+                        navController.popBackStack()
+                    }
+                },
+            )
+        }
+
         WebView(
             state = webViewState,
             navigator = webViewNavigator,

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
@@ -62,6 +62,7 @@ import com.mbj.doeat.BuildConfig
 import com.mbj.doeat.data.remote.model.Party
 import com.mbj.doeat.data.remote.model.SearchItem
 import com.mbj.doeat.ui.component.LongRectangleButtonWithParams
+import com.mbj.doeat.ui.component.YesNoDialog
 import com.mbj.doeat.ui.screen.home.detail.viewmodel.DetailViewModel
 import com.mbj.doeat.ui.theme.Beige100
 import com.mbj.doeat.ui.theme.Gray200
@@ -76,9 +77,10 @@ fun DetailScreen(searchItem: SearchItem, navController: NavHostController, onCli
 
     val searchItemState by viewModel.searchItem.collectAsState()
     val partyListState by viewModel.partyList.collectAsState()
-    val recruitmentCount by viewModel.recruitmentCount.collectAsState()
-    val recruitmentDetails by viewModel.recruitmentDetails.collectAsState()
+    val recruitmentCountState by viewModel.recruitmentCount.collectAsState()
+    val recruitmentDetailsState by viewModel.recruitmentDetails.collectAsState()
     val isBottomSheetExpandedState by viewModel.isBottomSheetExpanded.collectAsState()
+    val showCreatePartyDialogState by viewModel.showCreatePartyDialog.collectAsState()
 
     val webViewClient = AccompanistWebViewClient()
     val webChromeClient = AccompanistWebChromeClient()
@@ -104,9 +106,10 @@ fun DetailScreen(searchItem: SearchItem, navController: NavHostController, onCli
                     .offset(y = 15.dp)
             ) {
                 DetailBottomSheet(
+                    viewModel = viewModel,
                     party = searchItemState,
-                    recruitmentCount = recruitmentCount,
-                    recruitmentDetails = recruitmentDetails,
+                    recruitmentCount = recruitmentCountState,
+                    recruitmentDetails = recruitmentDetailsState,
                     onRecruitmentCountChange = { newCount ->
                         viewModel.changeRecruitmentCount(newCount)
                     }
@@ -131,6 +134,15 @@ fun DetailScreen(searchItem: SearchItem, navController: NavHostController, onCli
                 onClick = onClick,
                 padding = padding
             )
+            YesNoDialog(
+                showDialog = showCreatePartyDialogState,
+                onYesClick = { viewModel.postParty(navHostController = navController) },
+                onNoClick = { viewModel.changeShowCreatePartyDialog(showDialog = false) },
+                title = "파티를 모집하시겠습니까?",
+                message = "파티가 등록됩니다.",
+                confirmButtonMessage = "등록",
+                dismissButtonMessage = "취소"
+            )
         }
     )
 }
@@ -141,7 +153,6 @@ fun initializeWebView(searchItemState: SearchItem?) = rememberWebViewState(
     additionalHttpHeaders = emptyMap()
 )
 
-@Composable
 fun getUrl(searchItemState: SearchItem?): String {
     return if (searchItemState?.link == "") {
         "${BuildConfig.NAVER_SEARCH_BASE_URL}search.naver?query=${searchItemState?.title}"
@@ -319,6 +330,7 @@ fun CreatePartyButton(onClick: () -> Unit) {
 
 @Composable
 fun DetailBottomSheet(
+    viewModel: DetailViewModel,
     party: SearchItem?,
     recruitmentCount: String,
     recruitmentDetails: String,
@@ -331,7 +343,7 @@ fun DetailBottomSheet(
             .padding(16.dp)
     ) {
         Text(
-            text = "같이 살 사람 구하기",
+            text = "같이 갈 사람 구하기",
             fontSize = 26.sp,
             fontWeight = FontWeight.Bold,
             color = Color.Black
@@ -461,7 +473,9 @@ fun DetailBottomSheet(
             backgroundColor = Remon400,
             contentColor = Color.Black,
             shape = RoundedCornerShape(12.dp)
-        ) {}
+        ) {
+            viewModel.changeShowCreatePartyDialog(showDialog = true)
+        }
     }
 }
 

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
@@ -63,6 +63,7 @@ import com.mbj.doeat.BuildConfig
 import com.mbj.doeat.data.remote.model.Party
 import com.mbj.doeat.data.remote.model.SearchItem
 import com.mbj.doeat.ui.component.LongRectangleButtonWithParams
+import com.mbj.doeat.ui.component.ToastMessage
 import com.mbj.doeat.ui.component.YesNoDialog
 import com.mbj.doeat.ui.screen.home.detail.viewmodel.DetailViewModel
 import com.mbj.doeat.ui.theme.Beige100
@@ -125,6 +126,7 @@ fun DetailScreen(searchItem: SearchItem, navController: NavHostController, onCli
         sheetPeekHeight = 0.dp,
         content = { padding ->
             ExpandBottomSheetIfRequired(bottomSheetState, isBottomSheetExpandedState)
+
             DetailContent(
                 viewModel = viewModel,
                 navController = navController,
@@ -136,6 +138,7 @@ fun DetailScreen(searchItem: SearchItem, navController: NavHostController, onCli
                 onClick = onClick,
                 padding = padding
             )
+
             YesNoDialog(
                 showDialog = showCreatePartyDialogState,
                 onYesClick = { viewModel.postParty(navHostController = navController) },
@@ -226,6 +229,13 @@ fun DetailContent(
                     tint = Yellow700
                 )
             }
+
+            ToastMessage(
+                modifier = Modifier.padding(16.dp).align(Alignment.TopCenter),
+                showToast = viewModel.showValidRecruitmentCount.collectAsState().value,
+                showMessage = viewModel.isValidRecruitmentCount.collectAsState(initial = false).value,
+                message = "모집인원을 입력해주세요."
+            )
         }
 
         Text(

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
@@ -1,0 +1,29 @@
+package com.mbj.doeat.ui.screen.home.detail
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.navigation.NavHostController
+import com.mbj.doeat.data.remote.model.SearchItem
+
+@Composable
+fun DetailScreen(searchItem: SearchItem, navController: NavHostController, onClick: () -> Unit) {
+
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            modifier = Modifier.clickable { onClick() },
+            text = searchItem.roadAddress,
+            fontSize = MaterialTheme.typography.h3.fontSize,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
@@ -62,6 +62,7 @@ import com.google.accompanist.web.rememberWebViewState
 import com.mbj.doeat.BuildConfig
 import com.mbj.doeat.data.remote.model.Party
 import com.mbj.doeat.data.remote.model.SearchItem
+import com.mbj.doeat.ui.component.LoadingView
 import com.mbj.doeat.ui.component.LongRectangleButtonWithParams
 import com.mbj.doeat.ui.component.ToastMessage
 import com.mbj.doeat.ui.component.YesNoDialog
@@ -178,84 +179,95 @@ fun DetailContent(
     onClick: () -> Unit,
     padding: PaddingValues
 ) {
-    Column(
-        modifier = Modifier.fillMaxSize()
+    val isPostLoadingViewState by viewModel.isPostLoadingView.collectAsState()
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(8.dp),
-            horizontalArrangement = Arrangement.Start
+        Column(
+            modifier = Modifier.fillMaxSize()
         ) {
-            BackButton(navController)
-        }
-
-        Box(
-            modifier = Modifier
-                .fillMaxHeight(0.5f)
-                .fillMaxWidth()
-                .padding(start = 4.dp, end = 4.dp)
-        ) {
-            WebView(
-                state = webViewState,
-                navigator = webViewNavigator,
-                client = webViewClient,
-                chromeClient = webChromeClient,
-                onCreated = { webView ->
-                    with(webView) {
-                        settings.run {
-                            javaScriptEnabled = true
-                            domStorageEnabled = true
-                            javaScriptCanOpenWindowsAutomatically = false
-                        }
-                    }
-                },
-                modifier = Modifier.fillMaxSize()
-            )
-
-            IconButton(
-                onClick = {
-                    if (webViewNavigator.canGoBack) {
-                        webViewNavigator.navigateBack()
-                    }
-                },
+            Row(
                 modifier = Modifier
-                    .padding(16.dp)
-                    .align(Alignment.TopStart)
+                    .fillMaxWidth()
+                    .padding(8.dp),
+                horizontalArrangement = Arrangement.Start
             ) {
-                Icon(
-                    imageVector = Icons.Default.ArrowBack,
-                    contentDescription = "뒤로 가기",
-                    tint = Yellow700
+                BackButton(navController)
+            }
+
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight(0.5f)
+                    .fillMaxWidth()
+                    .padding(start = 4.dp, end = 4.dp)
+            ) {
+                WebView(
+                    state = webViewState,
+                    navigator = webViewNavigator,
+                    client = webViewClient,
+                    chromeClient = webChromeClient,
+                    onCreated = { webView ->
+                        with(webView) {
+                            settings.run {
+                                javaScriptEnabled = true
+                                domStorageEnabled = true
+                                javaScriptCanOpenWindowsAutomatically = false
+                            }
+                        }
+                    },
+                    modifier = Modifier.fillMaxSize()
+                )
+
+                IconButton(
+                    onClick = {
+                        if (webViewNavigator.canGoBack) {
+                            webViewNavigator.navigateBack()
+                        }
+                    },
+                    modifier = Modifier
+                        .padding(16.dp)
+                        .align(Alignment.TopStart)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.ArrowBack,
+                        contentDescription = "뒤로 가기",
+                        tint = Yellow700
+                    )
+                }
+
+                ToastMessage(
+                    modifier = Modifier.padding(16.dp).align(Alignment.TopCenter),
+                    showToast = viewModel.showValidRecruitmentCount.collectAsState().value,
+                    showMessage = viewModel.isValidRecruitmentCount.collectAsState(initial = false).value,
+                    message = "모집인원을 입력해주세요."
                 )
             }
 
-            ToastMessage(
-                modifier = Modifier.padding(16.dp).align(Alignment.TopCenter),
-                showToast = viewModel.showValidRecruitmentCount.collectAsState().value,
-                showMessage = viewModel.isValidRecruitmentCount.collectAsState(initial = false).value,
-                message = "모집인원을 입력해주세요."
+            Text(
+                text = "현재 개설된 파티",
+                fontWeight = FontWeight.Bold,
+                fontSize = 28.sp,
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(top = 10.dp, bottom = 10.dp)
             )
+
+            PartiesSection(
+                viewModel = viewModel,
+                partyListState = partyListState
+            ) {
+            }
+
+            CreatePartyButton(onClick = {
+                viewModel.toggleBottomSheetState()
+            })
         }
 
-        Text(
-            text = "현재 개설된 파티",
-            fontWeight = FontWeight.Bold,
-            fontSize = 28.sp,
-            modifier = Modifier
-                .align(Alignment.CenterHorizontally)
-                .padding(top = 10.dp, bottom = 10.dp)
+        LoadingView(
+            isLoading = isPostLoadingViewState,
         )
-
-        PartiesSection(
-            viewModel = viewModel,
-            partyListState = partyListState
-        ) {
-        }
-
-        CreatePartyButton(onClick = {
-            viewModel.toggleBottomSheetState()
-        })
     }
 }
 

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
@@ -1,21 +1,33 @@
 package com.mbj.doeat.ui.screen.home.detail
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
+import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import com.google.accompanist.web.AccompanistWebChromeClient
 import com.google.accompanist.web.AccompanistWebViewClient
@@ -23,8 +35,12 @@ import com.google.accompanist.web.WebView
 import com.google.accompanist.web.rememberWebViewNavigator
 import com.google.accompanist.web.rememberWebViewState
 import com.mbj.doeat.BuildConfig
+import com.mbj.doeat.data.remote.model.Party
 import com.mbj.doeat.data.remote.model.SearchItem
 import com.mbj.doeat.ui.screen.home.detail.viewmodel.DetailViewModel
+import com.mbj.doeat.ui.theme.Beige100
+import com.mbj.doeat.ui.theme.DoEatTheme
+import com.mbj.doeat.ui.theme.Remon400
 import com.mbj.doeat.util.UrlUtils
 
 @Composable
@@ -86,9 +102,125 @@ fun DetailScreen(searchItem: SearchItem, navController: NavHostController, onCli
                 }
             },
             modifier = Modifier
-                .fillMaxHeight(0.6f)
+                .fillMaxHeight(0.5f)
                 .fillMaxWidth()
                 .padding(8.dp)
         )
     }
-}
+
+    @Composable
+    fun PartyItem(
+        party: Party,
+        onJoinClick: (Party) -> Unit
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp)
+                .background(Beige100, shape = RoundedCornerShape(12.dp))
+                .border(1.dp, Color.Gray, shape = RoundedCornerShape(12.dp))
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp)
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    Text(
+                        text = party.restaurantName,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 18.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        color = Color.Black,
+                        modifier = Modifier
+                            .fillMaxWidth(0.6f)
+                    )
+
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    Text(
+                        text = party.category,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 12.sp,
+                        color = Color.Gray,
+                        modifier = Modifier.align(Alignment.CenterVertically),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+
+                Text(
+                    text = party.restaurantLocation,
+                    fontSize = 11.sp,
+                    color = Color.Black,
+                    modifier = Modifier.padding(top = 4.dp)
+
+                )
+
+                Text(
+                    text = party.detail,
+                    fontSize = 14.sp,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    color = Color.Gray,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 20.dp)
+                        .clickable {
+                            onJoinClick(party)
+                        },
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "${party.currentNumberPeople} / ${party.recruitmentLimit}",
+                        fontSize = 22.sp,
+                        color = Color.Black,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier
+                    )
+
+                    Spacer(modifier = Modifier.width(40.dp))
+
+                    Text(
+                        text = "참가하기",
+                        fontWeight = FontWeight.Bold,
+                        color = Color.Black,
+                        modifier = Modifier
+                            .background(Remon400, shape = RoundedCornerShape(4.dp))
+                            .padding(4.dp)
+                            .clickable {
+                                /**
+                                 * 채팅방 참가하기 TODO
+                                 */
+                                onJoinClick
+                            }
+                    )
+                }
+            }
+        }
+    }
+
+    @Preview
+    @Composable
+    fun PartyItemPreview() {
+        DoEatTheme {
+            val dummyParty = Party(
+                postId = 11,
+                userId = 4,
+                restaurantName = "마노디셰프1231231212231231313131313123",
+                restaurantLocation = "서울특별시 송파구 송파대로 570 타워 730 B1",
+                recruitmentLimit = 10,
+                currentNumberPeople = 5,
+                detail = "This is a party description. This is a party description. This is a party description. This is a party description. This is a party description. This is a party description.",
+                link = "",
+                category = "음식점>이탈리아 음식 12313123131312312"
+            )
+            PartyItem(party = dummyParty, onJoinClick = {})
+        }
+    }

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -16,6 +17,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -40,6 +42,7 @@ import com.google.accompanist.web.rememberWebViewState
 import com.mbj.doeat.BuildConfig
 import com.mbj.doeat.data.remote.model.Party
 import com.mbj.doeat.data.remote.model.SearchItem
+import com.mbj.doeat.ui.component.LongRectangleButtonWithParams
 import com.mbj.doeat.ui.screen.home.detail.viewmodel.DetailViewModel
 import com.mbj.doeat.ui.theme.Beige100
 import com.mbj.doeat.ui.theme.DoEatTheme
@@ -69,69 +72,86 @@ fun DetailScreen(searchItem: SearchItem, navController: NavHostController, onCli
 
     val partyListState by viewModel.partyList.collectAsState()
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(8.dp),
-            horizontalArrangement = Arrangement.Start
-        ) {
-            Icon(
-                imageVector = Icons.Default.ArrowBack,
-                contentDescription = "뒤로 가기",
-                modifier = Modifier.clickable {
-                    if (webViewNavigator.canGoBack) {
-                        webViewNavigator.navigateBack()
-                    } else {
-                        navController.popBackStack()
-                    }
-                },
-            )
-        }
+    Scaffold(
+        bottomBar = {
+            LongRectangleButtonWithParams(
+                text = "파티원 구하기",
+                fontSize = 20.sp,
+                height = 60.dp,
+                useFillMaxWidth = true,
+                padding = PaddingValues(top = 5.dp, bottom = 5.dp, start = 15.dp, end = 15.dp),
+                backgroundColor = Remon400,
+                contentColor = Color.Black,
+                shape = RoundedCornerShape(12.dp)
+            ) {
+            }
+        },
+        content = { padding ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp),
+                    horizontalArrangement = Arrangement.Start
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.ArrowBack,
+                        contentDescription = "뒤로 가기",
+                        modifier = Modifier.clickable {
+                            if (webViewNavigator.canGoBack) {
+                                webViewNavigator.navigateBack()
+                            } else {
+                                navController.popBackStack()
+                            }
+                        },
+                    )
+                }
 
-        WebView(
-            state = webViewState,
-            navigator = webViewNavigator,
-            client = webViewClient,
-            chromeClient = webChromeClient,
-            onCreated = { webView ->
-                with(webView) {
-                    settings.run {
-                        javaScriptEnabled = true
-                        domStorageEnabled = true
-                        javaScriptCanOpenWindowsAutomatically = false
+                WebView(
+                    state = webViewState,
+                    navigator = webViewNavigator,
+                    client = webViewClient,
+                    chromeClient = webChromeClient,
+                    onCreated = { webView ->
+                        with(webView) {
+                            settings.run {
+                                javaScriptEnabled = true
+                                domStorageEnabled = true
+                                javaScriptCanOpenWindowsAutomatically = false
+                            }
+                        }
+                    },
+                    modifier = Modifier
+                        .fillMaxHeight(0.5f)
+                        .fillMaxWidth()
+                        .padding(start = 4.dp, end = 4.dp)
+                )
+
+                Text(
+                    text = "현재 개설된 파티",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 28.sp,
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(top = 10.dp, bottom = 10.dp)
+                )
+
+                LazyColumn(
+                    modifier = Modifier.padding(bottom = 80.dp)
+                ) {
+                    items(
+                        items = partyListState,
+                        key = { party -> party.postId }
+                    ) { party ->
+                        PartyItem(party = party, onJoinClick = {})
                     }
                 }
-            },
-            modifier = Modifier
-                .fillMaxHeight(0.5f)
-                .fillMaxWidth()
-                .padding(8.dp)
-        )
-
-        Text(
-            text = "현재 개설된 파티",
-            fontWeight = FontWeight.Bold,
-            fontSize = 28.sp,
-            modifier = Modifier
-                .align(Alignment.CenterHorizontally)
-                .padding(top = 10.dp, bottom = 10.dp)
-        )
-
-        LazyColumn(
-            modifier = Modifier.padding(bottom = 80.dp)
-        ) {
-            items(
-                items = partyListState,
-                key = { party -> party.postId }
-            ) { party ->
-                PartyItem(party = party, onJoinClick = {})
             }
         }
-    }
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/viewmodel/DetailViewModel.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/viewmodel/DetailViewModel.kt
@@ -2,10 +2,15 @@ package com.mbj.doeat.ui.screen.home.detail.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.NavHostController
 import com.mbj.doeat.data.remote.model.Party
+import com.mbj.doeat.data.remote.model.PartyPostRequest
 import com.mbj.doeat.data.remote.model.SearchItem
 import com.mbj.doeat.data.remote.network.adapter.ApiResultSuccess
 import com.mbj.doeat.data.remote.network.api.default_db.repository.DefaultDBRepository
+import com.mbj.doeat.ui.graph.Graph
+import com.mbj.doeat.ui.screen.home.detail.getUrl
+import com.mbj.doeat.util.UserDataStore
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -30,6 +35,9 @@ class DetailViewModel @Inject constructor(private val defaultDBRepository: Defau
 
     private val _isBottomSheetExpanded = MutableStateFlow<Boolean>(false)
     val isBottomSheetExpanded: StateFlow<Boolean> = _isBottomSheetExpanded
+
+    private val _showCreatePartyDialog = MutableStateFlow<Boolean>(false)
+    val showCreatePartyDialog: StateFlow<Boolean> = _showCreatePartyDialog
 
     init {
         viewModelScope.launch {
@@ -59,6 +67,35 @@ class DetailViewModel @Inject constructor(private val defaultDBRepository: Defau
         }
     }
 
+    fun postParty(navHostController: NavHostController) {
+        viewModelScope.launch {
+            defaultDBRepository.postParty(
+                PartyPostRequest(
+                    userId = UserDataStore.getLoginResponse()?.userId!!,
+                    restaurantName = searchItem.value?.title ?: "",
+                    category = searchItem.value?.category ?: "",
+                    restaurantLocation = searchItem.value?.roadAddress ?: "",
+                    recruitmentLimit = recruitmentCount.value.toInt(),
+                    currentNumberPeople = 1,
+                    detail = recruitmentDetails.value,
+                    link = getUrl(searchItem.value)
+                ),
+                onComplete = {
+                },
+                onError = {
+                }
+            ).collectLatest { party ->
+                if (party is ApiResultSuccess) {
+                    navHostController.navigate(Graph.HOME) {
+                        popUpTo(navHostController.graph.id) {
+                            inclusive = true
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     fun changeRecruitmentCount(recruitCount: String) {
         _recruitmentCount.value = recruitCount
     }
@@ -69,5 +106,9 @@ class DetailViewModel @Inject constructor(private val defaultDBRepository: Defau
 
     fun toggleBottomSheetState() {
         _isBottomSheetExpanded.value = !_isBottomSheetExpanded.value
+    }
+
+    fun changeShowCreatePartyDialog(showDialog: Boolean) {
+        _showCreatePartyDialog.value = showDialog
     }
 }

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/viewmodel/DetailViewModel.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/viewmodel/DetailViewModel.kt
@@ -48,6 +48,9 @@ class DetailViewModel @Inject constructor(private val defaultDBRepository: Defau
     private val _showValidRecruitmentCount = MutableStateFlow<Boolean>(false)
     val showValidRecruitmentCount: StateFlow<Boolean> = _showValidRecruitmentCount
 
+    private val _isPostLoadingView = MutableStateFlow<Boolean>(false)
+    val isPostLoadingView: StateFlow<Boolean> = _isPostLoadingView
+
     init {
         viewModelScope.launch {
             searchItem.collectLatest { searchItem ->
@@ -82,6 +85,7 @@ class DetailViewModel @Inject constructor(private val defaultDBRepository: Defau
                 _showCreatePartyDialog.value = false
                 toggleValidToggleRecruitmentCountState()
             } else {
+                setPostLoadingState(true)
                 defaultDBRepository.postParty(
                     PartyPostRequest(
                         userId = UserDataStore.getLoginResponse()?.userId!!,
@@ -99,6 +103,7 @@ class DetailViewModel @Inject constructor(private val defaultDBRepository: Defau
                     }
                 ).collectLatest { party ->
                     if (party is ApiResultSuccess) {
+                        setPostLoadingState(false)
                         navHostController.navigate(Graph.HOME) {
                             popUpTo(navHostController.graph.id) {
                                 inclusive = true
@@ -131,5 +136,9 @@ class DetailViewModel @Inject constructor(private val defaultDBRepository: Defau
             _isValidRecruitmentCount.emit(true)
             _showValidRecruitmentCount.value = !_showValidRecruitmentCount.value
         }
+    }
+
+    private fun setPostLoadingState(isLoading: Boolean) {
+        _isPostLoadingView.value = isLoading
     }
 }

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/viewmodel/DetailViewModel.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/viewmodel/DetailViewModel.kt
@@ -1,16 +1,52 @@
 package com.mbj.doeat.ui.screen.home.detail.viewmodel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.mbj.doeat.data.remote.model.Party
 import com.mbj.doeat.data.remote.model.SearchItem
+import com.mbj.doeat.data.remote.network.adapter.ApiResultSuccess
+import com.mbj.doeat.data.remote.network.api.default_db.repository.DefaultDBRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class DetailViewModel : ViewModel() {
+@HiltViewModel
+class DetailViewModel @Inject constructor(private val defaultDBRepository: DefaultDBRepository) : ViewModel() {
+
+    private val _partyList = MutableStateFlow<List<Party>>((emptyList()))
+    val partyList: StateFlow<List<Party>> = _partyList
 
     private val _searchItem = MutableStateFlow<SearchItem?>(null)
     val searchItem: StateFlow<SearchItem?> = _searchItem
 
+    init {
+        viewModelScope.launch {
+            searchItem.collectLatest { searchItem ->
+                if (searchItem != null) {
+                    getPartiesByLocation(restaurantLocation = searchItem.roadAddress)
+                }
+            }
+        }
+    }
+
     fun updateSearchItem(inputSearchItem: SearchItem) {
         _searchItem.value = inputSearchItem
+    }
+
+    private suspend fun getPartiesByLocation(restaurantLocation: String) {
+        defaultDBRepository.getPartiesByLocation(
+            restaurantLocation,
+            onComplete = {
+            },
+            onError = {
+            }
+        ).collectLatest { responsePartyList ->
+            if (responsePartyList is ApiResultSuccess) {
+                _partyList.value = responsePartyList.data
+            }
+        }
     }
 }

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/viewmodel/DetailViewModel.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/viewmodel/DetailViewModel.kt
@@ -1,0 +1,16 @@
+package com.mbj.doeat.ui.screen.home.detail.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.mbj.doeat.data.remote.model.SearchItem
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class DetailViewModel : ViewModel() {
+
+    private val _searchItem = MutableStateFlow<SearchItem?>(null)
+    val searchItem: StateFlow<SearchItem?> = _searchItem
+
+    fun updateSearchItem(inputSearchItem: SearchItem) {
+        _searchItem.value = inputSearchItem
+    }
+}

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/viewmodel/DetailViewModel.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/viewmodel/DetailViewModel.kt
@@ -28,6 +28,9 @@ class DetailViewModel @Inject constructor(private val defaultDBRepository: Defau
     private val _recruitmentDetails = MutableStateFlow("")
     val recruitmentDetails: StateFlow<String> = _recruitmentDetails
 
+    private val _isBottomSheetExpanded = MutableStateFlow<Boolean>(false)
+    val isBottomSheetExpanded: StateFlow<Boolean> = _isBottomSheetExpanded
+
     init {
         viewModelScope.launch {
             searchItem.collectLatest { searchItem ->
@@ -62,5 +65,9 @@ class DetailViewModel @Inject constructor(private val defaultDBRepository: Defau
 
     fun changeRecruitmentDetails(recruitDetails: String) {
         _recruitmentDetails.value = recruitDetails
+    }
+
+    fun toggleBottomSheetState() {
+        _isBottomSheetExpanded.value = !_isBottomSheetExpanded.value
     }
 }

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/viewmodel/DetailViewModel.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/viewmodel/DetailViewModel.kt
@@ -22,6 +22,12 @@ class DetailViewModel @Inject constructor(private val defaultDBRepository: Defau
     private val _searchItem = MutableStateFlow<SearchItem?>(null)
     val searchItem: StateFlow<SearchItem?> = _searchItem
 
+    private val _recruitmentCount = MutableStateFlow("")
+    val recruitmentCount: StateFlow<String> = _recruitmentCount
+
+    private val _recruitmentDetails = MutableStateFlow("")
+    val recruitmentDetails: StateFlow<String> = _recruitmentDetails
+
     init {
         viewModelScope.launch {
             searchItem.collectLatest { searchItem ->
@@ -48,5 +54,13 @@ class DetailViewModel @Inject constructor(private val defaultDBRepository: Defau
                 _partyList.value = responsePartyList.data
             }
         }
+    }
+
+    fun changeRecruitmentCount(recruitCount: String) {
+        _recruitmentCount.value = recruitCount
+    }
+
+    fun changeRecruitmentDetails(recruitDetails: String) {
+        _recruitmentDetails.value = recruitDetails
     }
 }

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/nearby_restaurants/NearbyRestaurantsScreen.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/nearby_restaurants/NearbyRestaurantsScreen.kt
@@ -67,12 +67,15 @@ import com.mbj.doeat.ui.component.LongRectangleButtonWithParams
 import com.mbj.doeat.ui.component.MainAppBar
 import com.mbj.doeat.ui.component.RoundedLine
 import com.mbj.doeat.ui.component.ToastMessage
+import com.mbj.doeat.ui.graph.DetailScreen
 import com.mbj.doeat.ui.model.SearchWidgetState
 import com.mbj.doeat.ui.screen.home.nearby_restaurants.viewmodel.NearByRestaurantsViewModel
 import com.mbj.doeat.ui.theme.Yellow700
 import com.mbj.doeat.ui.theme.randomColors
 import com.mbj.doeat.util.MapConverter.formatLatLng
 import com.mbj.doeat.util.MapConverter.removeHtmlTags
+import com.mbj.doeat.util.NavigationUtils
+import com.mbj.doeat.util.UrlUtils
 
 @OptIn(ExperimentalNaverMapApi::class, ExperimentalMaterialApi::class)
 @Composable
@@ -144,7 +147,7 @@ fun NearbyRestaurantsScreen(
                     .clip(RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp))
                     .offset(y = 15.dp)
             ) {
-                MyBottomSheetContent(viewModel, cameraPositionState)
+                MyBottomSheetContent(viewModel, cameraPositionState, navController)
             }
         },
         sheetPeekHeight = 150.dp,
@@ -261,7 +264,7 @@ fun updateMyLocation(
 }
 
 @Composable
-fun MyBottomSheetContent(viewModel: NearByRestaurantsViewModel, cameraPositionState: CameraPositionState) {
+fun MyBottomSheetContent(viewModel: NearByRestaurantsViewModel, cameraPositionState: CameraPositionState, navController: NavHostController) {
     val searchResult by viewModel.searchResult.collectAsState(initial = SearchResult(emptyList()))
     Column(
         modifier = Modifier
@@ -289,7 +292,7 @@ fun MyBottomSheetContent(viewModel: NearByRestaurantsViewModel, cameraPositionSt
                 items = searchResult.items,
                 key = { searchItem -> searchItem.hashCode() }
             ) { searchItem ->
-                MyBottomSheetContentItem(searchItem = searchItem, cameraPositionState = cameraPositionState)
+                MyBottomSheetContentItem(searchItem = searchItem, cameraPositionState = cameraPositionState, navController = navController)
             }
         }
     }
@@ -297,7 +300,7 @@ fun MyBottomSheetContent(viewModel: NearByRestaurantsViewModel, cameraPositionSt
 
 @OptIn(ExperimentalNaverMapApi::class)
 @Composable
-fun MyBottomSheetContentItem(searchItem: SearchItem,cameraPositionState: CameraPositionState,) {
+fun MyBottomSheetContentItem(searchItem: SearchItem,cameraPositionState: CameraPositionState, navController: NavHostController) {
     Spacer(modifier = Modifier.height(16.dp))
     Column(modifier = Modifier.clickable {
         cameraPositionState.move(

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/nearby_restaurants/NearbyRestaurantsScreen.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/nearby_restaurants/NearbyRestaurantsScreen.kt
@@ -75,7 +75,6 @@ import com.mbj.doeat.ui.theme.randomColors
 import com.mbj.doeat.util.MapConverter.formatLatLng
 import com.mbj.doeat.util.MapConverter.removeHtmlTags
 import com.mbj.doeat.util.NavigationUtils
-import com.mbj.doeat.util.UrlUtils
 import com.mbj.doeat.util.UrlUtils.encodeUrl
 
 @OptIn(ExperimentalNaverMapApi::class, ExperimentalMaterialApi::class)
@@ -99,6 +98,11 @@ fun NearbyRestaurantsScreen(
     val searchResultState by viewModel.searchResult.collectAsState(initial = SearchResult(emptyList()))
     val searchResultCollapseState by viewModel.searchResultCollapse.collectAsState(initial = false)
     val searchResultCollapseCountState by viewModel.searchResultCollapseCount.collectAsState()
+    val showLocationPermissionDeniedToastState = viewModel.showLocationPermissionDeniedToast.collectAsState().value
+    val isLocationPermissionDeniedState = viewModel.isLocationPermissionDenied.collectAsState(initial = false).value
+    val showSearchInvalidToastState = viewModel.showSearchInvalidToast.collectAsState().value
+    val isSearchInvalidState = viewModel.isSearchInvalid.collectAsState(initial = false).value
+
     val cameraPositionState: CameraPositionState = rememberCameraPositionState {
         position = CameraPosition(myLocationInfoState, 11.0)
     }
@@ -231,14 +235,14 @@ fun NearbyRestaurantsScreen(
                     .padding(16.dp)
                     .align(Alignment.BottomStart)
                     .offset(y = (-190).dp),
-                showMessage = viewModel.isLocationPermissionDenied.collectAsState(initial = false).value,
-                clickCount = viewModel.isLocationPermissionDeniedCount.collectAsState().value,
+                showToast = showLocationPermissionDeniedToastState,
+                showMessage = isLocationPermissionDeniedState,
                 message = "위치 권한이 거부되었습니다.\n허용 후 다시 시도해주세요."
             )
             ToastMessage(
                 modifier = Modifier.padding(16.dp),
-                showMessage = viewModel.isSearchInvalid.collectAsState(initial = false).value,
-                clickCount = viewModel.isSearchInvalidCount.collectAsState().value,
+                showToast = showSearchInvalidToastState,
+                showMessage = isSearchInvalidState,
                 message = "올바른 지역을 입력해주세요."
             )
         }

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/nearby_restaurants/NearbyRestaurantsScreen.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/nearby_restaurants/NearbyRestaurantsScreen.kt
@@ -344,9 +344,12 @@ fun MyBottomSheetContentItem(searchItem: SearchItem,cameraPositionState: CameraP
             backgroundColor = Yellow700,
             contentColor = Color.Black
         ) {
-            /**
-             * 상세보기 버튼을 클릭했을 때 실행할 동작 TODO
-             */
+            val encodedLink = UrlUtils.encodeUrl(searchItem.link)
+            NavigationUtils.navigate(
+                navController, DetailScreen.Detail.navigateWithArg(
+                    searchItem.copy(link = encodedLink)
+                )
+            )
         }
         Divider(
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/nearby_restaurants/NearbyRestaurantsScreen.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/nearby_restaurants/NearbyRestaurantsScreen.kt
@@ -76,6 +76,7 @@ import com.mbj.doeat.util.MapConverter.formatLatLng
 import com.mbj.doeat.util.MapConverter.removeHtmlTags
 import com.mbj.doeat.util.NavigationUtils
 import com.mbj.doeat.util.UrlUtils
+import com.mbj.doeat.util.UrlUtils.encodeUrl
 
 @OptIn(ExperimentalNaverMapApi::class, ExperimentalMaterialApi::class)
 @Composable
@@ -344,10 +345,11 @@ fun MyBottomSheetContentItem(searchItem: SearchItem,cameraPositionState: CameraP
             backgroundColor = Yellow700,
             contentColor = Color.Black
         ) {
-            val encodedLink = UrlUtils.encodeUrl(searchItem.link)
+            val encodedLink = encodeUrl(searchItem.link)
+            val titleWithoutHtmlTags = removeHtmlTags(searchItem.title)
             NavigationUtils.navigate(
                 navController, DetailScreen.Detail.navigateWithArg(
-                    searchItem.copy(link = encodedLink)
+                    searchItem.copy(title = titleWithoutHtmlTags, link = encodedLink)
                 )
             )
         }

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/nearby_restaurants/NearbyRestaurantsScreen.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/nearby_restaurants/NearbyRestaurantsScreen.kt
@@ -97,9 +97,11 @@ fun NearbyRestaurantsScreen(
     val searchTextState by viewModel.searchTextState.collectAsState()
     val searchResultState by viewModel.searchResult.collectAsState(initial = SearchResult(emptyList()))
     val searchResultCollapseState by viewModel.searchResultCollapse.collectAsState(initial = false)
-    val searchResultCollapseCountState by viewModel.searchResultCollapseCount.collectAsState()
-    val showLocationPermissionDeniedToastState = viewModel.showLocationPermissionDeniedToast.collectAsState().value
-    val isLocationPermissionDeniedState = viewModel.isLocationPermissionDenied.collectAsState(initial = false).value
+    val showSearchResultCollapseState by viewModel.showSearchResultCollapse.collectAsState()
+    val showLocationPermissionDeniedToastState =
+        viewModel.showLocationPermissionDeniedToast.collectAsState().value
+    val isLocationPermissionDeniedState =
+        viewModel.isLocationPermissionDenied.collectAsState(initial = false).value
     val showSearchInvalidToastState = viewModel.showSearchInvalidToast.collectAsState().value
     val isSearchInvalidState = viewModel.isSearchInvalid.collectAsState(initial = false).value
 
@@ -183,7 +185,12 @@ fun NearbyRestaurantsScreen(
             )
         }
     ) {
-        CollapseBottomSheetIfRequired(bottomSheetState, searchResultCollapseState, searchResultCollapseCountState)
+        CollapseBottomSheetIfRequired(
+            bottomSheetState = bottomSheetState,
+            collapseOnEvent = showSearchResultCollapseState,
+            shouldCollapse = searchResultCollapseState
+        )
+
         Box(
             modifier = Modifier.fillMaxSize(),
         ) {
@@ -192,17 +199,27 @@ fun NearbyRestaurantsScreen(
                     searchResultState.items.forEachIndexed { index, searchItem ->
                         val iconTintColor = randomColors[index % randomColors.size]
                         Marker(
-                            state = MarkerState(position = formatLatLng(searchItem.mapy, searchItem.mapx)),
+                            state = MarkerState(
+                                position = formatLatLng(
+                                    searchItem.mapy,
+                                    searchItem.mapx
+                                )
+                            ),
                             captionText = removeHtmlTags(searchItem.title),
                             iconTintColor = iconTintColor
                         )
                     }
                     cameraPositionState.move(
-                        CameraUpdate.scrollAndZoomTo(formatLatLng(searchResultState.items.first().mapy, searchResultState.items.first().mapx), 18.0)
+                        CameraUpdate.scrollAndZoomTo(
+                            formatLatLng(
+                                searchResultState.items.first().mapy,
+                                searchResultState.items.first().mapx
+                            ), 18.0
+                        )
                             .animate(CameraAnimation.Easing)
                     )
                 }
-                if(myLocationInfoState != LatLng(37.532600, 127.024612)) {
+                if (myLocationInfoState != LatLng(37.532600, 127.024612)) {
                     Marker(
                         state = MarkerState(position = myLocationInfoState),
                         captionText = "내 위치",
@@ -269,7 +286,11 @@ fun updateMyLocation(
 }
 
 @Composable
-fun MyBottomSheetContent(viewModel: NearByRestaurantsViewModel, cameraPositionState: CameraPositionState, navController: NavHostController) {
+fun MyBottomSheetContent(
+    viewModel: NearByRestaurantsViewModel,
+    cameraPositionState: CameraPositionState,
+    navController: NavHostController
+) {
     val searchResult by viewModel.searchResult.collectAsState(initial = SearchResult(emptyList()))
     Column(
         modifier = Modifier
@@ -297,7 +318,11 @@ fun MyBottomSheetContent(viewModel: NearByRestaurantsViewModel, cameraPositionSt
                 items = searchResult.items,
                 key = { searchItem -> searchItem.hashCode() }
             ) { searchItem ->
-                MyBottomSheetContentItem(searchItem = searchItem, cameraPositionState = cameraPositionState, navController = navController)
+                MyBottomSheetContentItem(
+                    searchItem = searchItem,
+                    cameraPositionState = cameraPositionState,
+                    navController = navController
+                )
             }
         }
     }
@@ -305,7 +330,11 @@ fun MyBottomSheetContent(viewModel: NearByRestaurantsViewModel, cameraPositionSt
 
 @OptIn(ExperimentalNaverMapApi::class)
 @Composable
-fun MyBottomSheetContentItem(searchItem: SearchItem,cameraPositionState: CameraPositionState, navController: NavHostController) {
+fun MyBottomSheetContentItem(
+    searchItem: SearchItem,
+    cameraPositionState: CameraPositionState,
+    navController: NavHostController
+) {
     Spacer(modifier = Modifier.height(16.dp))
     Column(modifier = Modifier.clickable {
         cameraPositionState.move(
@@ -321,11 +350,14 @@ fun MyBottomSheetContentItem(searchItem: SearchItem,cameraPositionState: CameraP
                 modifier = Modifier
                     .padding(start = 10.dp, end = 10.dp)
             ) {
-                Text(text = removeHtmlTags(searchItem.title),
+                Text(
+                    text = removeHtmlTags(searchItem.title),
                     fontSize = 20.sp,
-                    fontWeight = FontWeight.Bold)
+                    fontWeight = FontWeight.Bold
+                )
                 Spacer(modifier = Modifier.width(5.dp))
-                Text(text = searchItem.category,
+                Text(
+                    text = searchItem.category,
                     fontSize = 14.sp,
                     fontWeight = FontWeight.Bold,
                     color = Color.Gray
@@ -337,12 +369,15 @@ fun MyBottomSheetContentItem(searchItem: SearchItem,cameraPositionState: CameraP
                 modifier = Modifier
                     .padding(start = 10.dp, end = 10.dp)
             ) {
-                Text(text = searchItem.roadAddress,
-                    fontSize = 16.sp)
+                Text(
+                    text = searchItem.roadAddress,
+                    fontSize = 16.sp
+                )
             }
         }
         Spacer(modifier = Modifier.height(8.dp))
-        LongRectangleButtonWithParams(text = "상세보기",
+        LongRectangleButtonWithParams(
+            text = "상세보기",
             height = 40.dp,
             useFillMaxWidth = true,
             padding = PaddingValues(start = 30.dp, end = 30.dp, top = 10.dp, bottom = 10.dp),
@@ -405,10 +440,10 @@ fun handleLocationPermission(
 @Composable
 fun CollapseBottomSheetIfRequired(
     bottomSheetState: BottomSheetState,
+    collapseOnEvent: Boolean,
     shouldCollapse: Boolean,
-    eventCount: Int
 ) {
-    LaunchedEffect(eventCount) {
+    LaunchedEffect(collapseOnEvent) {
         if (shouldCollapse) {
             bottomSheetState.collapse()
         }

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/nearby_restaurants/viewmodel/NearByRestaurantsViewModel.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/nearby_restaurants/viewmodel/NearByRestaurantsViewModel.kt
@@ -49,8 +49,8 @@ class NearByRestaurantsViewModel @Inject constructor(
     private val _searchResultCollapse = MutableSharedFlow<Boolean>()
     val searchResultCollapse: SharedFlow<Boolean> = _searchResultCollapse
 
-    private val _searchResultCollapseCount = MutableStateFlow<Int>(0)
-    val searchResultCollapseCount: StateFlow<Int> = _searchResultCollapseCount
+    private val _showSearchResultCollapse = MutableStateFlow<Boolean>(false)
+    val showSearchResultCollapse: StateFlow<Boolean> = _showSearchResultCollapse
 
     init {
         viewModelScope.launch {
@@ -106,7 +106,7 @@ class NearByRestaurantsViewModel @Inject constructor(
     fun toggleSearchResultCollapsed() {
         viewModelScope.launch {
             _searchResultCollapse.emit(true)
-            _searchResultCollapseCount.value = _searchResultCollapseCount.value + 1
+            _showSearchResultCollapse.value = !_showSearchResultCollapse.value
         }
     }
 }

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/nearby_restaurants/viewmodel/NearByRestaurantsViewModel.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/nearby_restaurants/viewmodel/NearByRestaurantsViewModel.kt
@@ -28,8 +28,8 @@ class NearByRestaurantsViewModel @Inject constructor(
     private val _isLocationPermissionDenied = MutableSharedFlow<Boolean>()
     val isLocationPermissionDenied: SharedFlow<Boolean> = _isLocationPermissionDenied.asSharedFlow()
 
-    private val _isLocationPermissionDeniedCount = MutableStateFlow<Int>(0)
-    val isLocationPermissionDeniedCount: StateFlow<Int> = _isLocationPermissionDeniedCount
+    private val _showLocationPermissionDeniedToast = MutableStateFlow<Boolean>(false)
+    val showLocationPermissionDeniedToast: StateFlow<Boolean> = _showLocationPermissionDeniedToast
 
     private val _searchResult = MutableSharedFlow<SearchResult>()
     val searchResult: SharedFlow<SearchResult> = _searchResult.asSharedFlow()
@@ -43,8 +43,8 @@ class NearByRestaurantsViewModel @Inject constructor(
     private val _isSearchInvalid = MutableSharedFlow<Boolean>()
     val isSearchInvalid: SharedFlow<Boolean> = _isSearchInvalid.asSharedFlow()
 
-    private val _isSearchInvalidCount = MutableStateFlow<Int>(0)
-    val isSearchInvalidCount: StateFlow<Int> = _isSearchInvalidCount
+    private val _showSearchInvalidToast = MutableStateFlow<Boolean>(false)
+    val showSearchInvalidToast: StateFlow<Boolean> = _showSearchInvalidToast
 
     private val _searchResultCollapse = MutableSharedFlow<Boolean>()
     val searchResultCollapse: SharedFlow<Boolean> = _searchResultCollapse
@@ -67,7 +67,7 @@ class NearByRestaurantsViewModel @Inject constructor(
     fun setLocationPermissionDenied() {
         viewModelScope.launch {
             _isLocationPermissionDenied.emit(true)
-            _isLocationPermissionDeniedCount.value = _isLocationPermissionDeniedCount.value + 1
+            _showLocationPermissionDeniedToast.value = !_showLocationPermissionDeniedToast.value
         }
     }
 
@@ -98,7 +98,7 @@ class NearByRestaurantsViewModel @Inject constructor(
         viewModelScope.launch {
             if (searchResult.items.isEmpty()) {
                 _isSearchInvalid.emit(true)
-                _isSearchInvalidCount.value = _isSearchInvalidCount.value + 1
+                _showSearchInvalidToast.value = !_showSearchInvalidToast.value
             }
         }
     }

--- a/app/src/main/java/com/mbj/doeat/ui/theme/Color.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/theme/Color.kt
@@ -8,8 +8,10 @@ val Purple700 = Color(0xFF3700B3)
 val Teal200 = Color(0xFF03DAC5)
 val Yellow700 = Color(0xFFFFEB23)
 val Gray200 = Color(0xFFB9B6B6)
+val Beige50 = Color(0xFFFFF1F1)
 val Beige100 = Color(0xFFEBDFDF)
 val Remon400 = Color(0xFFF4FF7F)
+val Pink500 = Color(0xFFFF7F7F)
 
 val randomColors = listOf(
     Color.Red,

--- a/app/src/main/java/com/mbj/doeat/ui/theme/Color.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/theme/Color.kt
@@ -12,6 +12,7 @@ val Beige50 = Color(0xFFFFF1F1)
 val Beige100 = Color(0xFFEBDFDF)
 val Remon400 = Color(0xFFF4FF7F)
 val Pink500 = Color(0xFFFF7F7F)
+val Black700 = Color(0x77000000)
 
 val randomColors = listOf(
     Color.Red,

--- a/app/src/main/java/com/mbj/doeat/ui/theme/Color.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/theme/Color.kt
@@ -8,6 +8,8 @@ val Purple700 = Color(0xFF3700B3)
 val Teal200 = Color(0xFF03DAC5)
 val Yellow700 = Color(0xFFFFEB23)
 val Gray200 = Color(0xFFB9B6B6)
+val Beige100 = Color(0xFFEBDFDF)
+val Remon400 = Color(0xFFF4FF7F)
 
 val randomColors = listOf(
     Color.Red,

--- a/app/src/main/java/com/mbj/doeat/util/SerializationUtils.kt
+++ b/app/src/main/java/com/mbj/doeat/util/SerializationUtils.kt
@@ -1,0 +1,19 @@
+package com.mbj.doeat.util
+
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+object SerializationUtils {
+    val json = Json
+
+    inline fun <reified T> toJson(value: T): String {
+        return json.encodeToString(value)
+    }
+
+    inline fun <reified T> fromJson(jsonString: String?): T? {
+        return runCatching {
+            json.decodeFromString<T>(jsonString ?: "")
+        }.getOrNull()
+    }
+}

--- a/app/src/main/java/com/mbj/doeat/util/UrlUtils.kt
+++ b/app/src/main/java/com/mbj/doeat/util/UrlUtils.kt
@@ -1,0 +1,29 @@
+package com.mbj.doeat.util
+
+import java.io.UnsupportedEncodingException
+import java.net.URLDecoder
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+object UrlUtils {
+
+    fun encodeUrl(url: String?): String {
+        if (url == null) {
+            return ""
+        }
+
+        return try {
+            URLEncoder.encode(url, StandardCharsets.UTF_8.toString())
+        } catch (e: UnsupportedEncodingException) {
+            throw RuntimeException("Error encoding URL parameter", e)
+        }
+    }
+
+    fun decodeUrl(encodedUrl: String): String {
+        return try {
+            URLDecoder.decode(encodedUrl, StandardCharsets.UTF_8.toString())
+        } catch (e: UnsupportedEncodingException) {
+            throw RuntimeException("Error decoding URL parameter", e)
+        }
+    }
+}


### PR DESCRIPTION
# 구현 내용

## DetailScreen 기능
- 해당 맛집에 대한 WebView 띄우기 / WebView 백스택 관리
- 해당 맛집의 개설된 파티 리스트를 보여주는 기능 / 개설된 파티가 없다면 없는 UI 구성
- '파티원 구하기' 버튼 클릭 시 숨겨져 있던 바텀 시트(파티 등록 Form) 띄위기
-  바텀 시트(파티 등록 Form)를 통해 파티 등록 기능 / 파티 등록 할 때 예외처리(모집인원 필드 누락) 완료

## DetailScreen UI 작업
- 파티 등록 할 때 예외 상황 발생 시 Custum Toast 메시지 띄우기
- 파티 등록 성공 시 LoadingView 띄위기

## 기타 작업
- JSON 직렬화 및 역직렬화를 위한 SerializationUtils 생성  
( 화면을 전환할 때 Primitive Data Type 이 아닌 Reference Data Type를 넘겨야 하는 상황이 있는데 이때 JSON 직렬화 및 역직렬화 할 때 사용 )
- 자동 로그인시 LoadingView 띄우기
- Detail Nav Graph 생성 및 이용
