### PR TITLE
[Refactor/flow collect state refactoring] UI에서 라이프사이클을 인지하는 방식을 통해 flow를 수집하는 방식으로 리팩토링

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,6 +88,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview:1.3.2")
     implementation("androidx.compose.material:material:1.0.1")
     implementation("androidx.activity:activity-compose:1.6.1")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.6.2")
 
     // Navigation
     implementation("androidx.navigation:navigation-fragment-ktx:2.5.3")

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/community/PostListScreen.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/community/PostListScreen.kt
@@ -8,12 +8,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mbj.doeat.ui.component.PartyList
 import com.mbj.doeat.ui.component.SearchAppBar
 import com.mbj.doeat.ui.screen.home.community.viewModel.PostListViewModel
@@ -24,8 +24,8 @@ fun PostListScreen(name: String, onClick: () -> Unit) {
 
     val viewModel: PostListViewModel = hiltViewModel()
 
-    val partyListState by  viewModel.partyList.collectAsState()
-    val searchFilterTextState by viewModel.searchBarText.collectAsState()
+    val partyListState by  viewModel.partyList.collectAsStateWithLifecycle()
+    val searchFilterTextState by viewModel.searchBarText.collectAsStateWithLifecycle()
     val filteredPartyList = viewModel.getFilteredPartyList(partyListState, searchFilterTextState)
 
     Box(

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/detail/DetailScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.material.rememberBottomSheetScaffoldState
 import androidx.compose.material.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -46,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.text.isDigitsOnly
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import com.google.accompanist.web.AccompanistWebChromeClient
 import com.google.accompanist.web.AccompanistWebViewClient
@@ -74,12 +74,12 @@ fun DetailScreen(searchItem: SearchItem, navController: NavHostController, onCli
     val viewModel: DetailViewModel = hiltViewModel()
     viewModel.updateSearchItem(searchItem)
 
-    val searchItemState by viewModel.searchItem.collectAsState()
-    val partyListState by viewModel.partyList.collectAsState()
-    val recruitmentCountState by viewModel.recruitmentCount.collectAsState()
-    val recruitmentDetailsState by viewModel.recruitmentDetails.collectAsState()
-    val isBottomSheetExpandedState by viewModel.isBottomSheetExpanded.collectAsState()
-    val showCreatePartyDialogState by viewModel.showCreatePartyDialog.collectAsState()
+    val searchItemState by viewModel.searchItem.collectAsStateWithLifecycle()
+    val partyListState by viewModel.partyList.collectAsStateWithLifecycle()
+    val recruitmentCountState by viewModel.recruitmentCount.collectAsStateWithLifecycle()
+    val recruitmentDetailsState by viewModel.recruitmentDetails.collectAsStateWithLifecycle()
+    val isBottomSheetExpandedState by viewModel.isBottomSheetExpanded.collectAsStateWithLifecycle()
+    val showCreatePartyDialogState by viewModel.showCreatePartyDialog.collectAsStateWithLifecycle()
 
     val webViewClient = AccompanistWebViewClient()
     val webChromeClient = AccompanistWebChromeClient()
@@ -174,7 +174,9 @@ fun DetailContent(
     onClick: () -> Unit,
     padding: PaddingValues
 ) {
-    val isPostLoadingViewState by viewModel.isPostLoadingView.collectAsState()
+    val isPostLoadingViewState by viewModel.isPostLoadingView.collectAsStateWithLifecycle()
+    val showValidRecruitmentCountState by viewModel.showValidRecruitmentCount.collectAsStateWithLifecycle()
+    val isValidRecruitmentCountState by viewModel.isValidRecruitmentCount.collectAsStateWithLifecycle(initialValue = false)
 
     Box(
         modifier = Modifier
@@ -233,9 +235,11 @@ fun DetailContent(
                 }
 
                 ToastMessage(
-                    modifier = Modifier.padding(16.dp).align(Alignment.TopCenter),
-                    showToast = viewModel.showValidRecruitmentCount.collectAsState().value,
-                    showMessage = viewModel.isValidRecruitmentCount.collectAsState(initial = false).value,
+                    modifier = Modifier
+                        .padding(16.dp)
+                        .align(Alignment.TopCenter),
+                    showToast = showValidRecruitmentCountState,
+                    showMessage = isValidRecruitmentCountState,
                     message = "모집인원을 입력해주세요."
                 )
             }

--- a/app/src/main/java/com/mbj/doeat/ui/screen/home/nearby_restaurants/NearbyRestaurantsScreen.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/home/nearby_restaurants/NearbyRestaurantsScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.material.rememberBottomSheetScaffoldState
 import androidx.compose.material.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -47,6 +46,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import com.mbj.doeat.R
 import com.mbj.doeat.ui.component.Image
@@ -92,18 +92,16 @@ fun NearbyRestaurantsScreen(
         Manifest.permission.ACCESS_FINE_LOCATION
     )
 
-    val myLocationInfoState by viewModel.location.collectAsState()
-    val searchWidgetState by viewModel.searchWidgetState.collectAsState()
-    val searchTextState by viewModel.searchTextState.collectAsState()
-    val searchResultState by viewModel.searchResult.collectAsState(initial = SearchResult(emptyList()))
-    val searchResultCollapseState by viewModel.searchResultCollapse.collectAsState(initial = false)
-    val showSearchResultCollapseState by viewModel.showSearchResultCollapse.collectAsState()
-    val showLocationPermissionDeniedToastState =
-        viewModel.showLocationPermissionDeniedToast.collectAsState().value
-    val isLocationPermissionDeniedState =
-        viewModel.isLocationPermissionDenied.collectAsState(initial = false).value
-    val showSearchInvalidToastState = viewModel.showSearchInvalidToast.collectAsState().value
-    val isSearchInvalidState = viewModel.isSearchInvalid.collectAsState(initial = false).value
+    val myLocationInfoState by viewModel.location.collectAsStateWithLifecycle()
+    val searchWidgetState by viewModel.searchWidgetState.collectAsStateWithLifecycle()
+    val searchTextState by viewModel.searchTextState.collectAsStateWithLifecycle()
+    val searchResultState by viewModel.searchResult.collectAsStateWithLifecycle(initialValue = SearchResult(emptyList()))
+    val searchResultCollapseState by viewModel.searchResultCollapse.collectAsStateWithLifecycle(initialValue = false)
+    val showSearchResultCollapseState by viewModel.showSearchResultCollapse.collectAsStateWithLifecycle()
+    val showLocationPermissionDeniedToastState by viewModel.showLocationPermissionDeniedToast.collectAsStateWithLifecycle()
+    val isLocationPermissionDeniedState by viewModel.isLocationPermissionDenied.collectAsStateWithLifecycle(initialValue = false)
+    val showSearchInvalidToastState by viewModel.showSearchInvalidToast.collectAsStateWithLifecycle()
+    val isSearchInvalidState by viewModel.isSearchInvalid.collectAsStateWithLifecycle(initialValue = false)
 
     val cameraPositionState: CameraPositionState = rememberCameraPositionState {
         position = CameraPosition(myLocationInfoState, 11.0)
@@ -291,7 +289,7 @@ fun MyBottomSheetContent(
     cameraPositionState: CameraPositionState,
     navController: NavHostController
 ) {
-    val searchResult by viewModel.searchResult.collectAsState(initial = SearchResult(emptyList()))
+    val searchResult by viewModel.searchResult.collectAsStateWithLifecycle(initialValue = SearchResult(emptyList()))
     Column(
         modifier = Modifier
             .fillMaxSize()

--- a/app/src/main/java/com/mbj/doeat/ui/screen/signin/SignInScreen.kt
+++ b/app/src/main/java/com/mbj/doeat/ui/screen/signin/SignInScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.material.CheckboxDefaults
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -31,6 +30,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.model.ClientError
@@ -51,8 +51,8 @@ fun SignInScreen(
 
     val context = LocalContext.current
 
-    val isAutoLogin by viewModel.isAutoLoginState.collectAsState()
-    val isLoadingView by viewModel.isLoadingView.collectAsState()
+    val isAutoLogin by viewModel.isAutoLoginState.collectAsStateWithLifecycle()
+    val isLoadingView by viewModel.isLoadingView.collectAsStateWithLifecycle()
 
     val kakaoCallback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
         viewModel.setLoadingState(true)


### PR DESCRIPTION
# 구현 내용
## UI에서 라이프사이클을 인지하는 방식을 통해 flow를 수집하는 방식으로 리팩토링( collectAsState -> collectAsStateWithLifecycle )  
리팩토링 이유 :  
 1. collectAsState는 Composition의 라이프사이클을 따른다. Compose는 Android 앱이 백그라운드에 있는 동안 recomposition을 중지하더라도 수집(collect) 작업이 계속 활성화 상태로 유지한다는 점이다.  
 (즉, 백그라운드 상태에서 수집 할만한 내용이 없어도 flow 수집 상태를 유지한다는 점이다.)  
2. collectAsStateWithLifecycle는 라이프사이클을 인지하는 방식으로 flow를 수집하기 때문에 화면에 보이지는 않지만 앱이 계속 실행 중인 상태인 백그라운드에 있을때에 수집(collect) 작업을 비활성화하여 앱의 리소스를 절약할 수 있기 때문이다.  
(즉, 백그라운드로 진입했을 때 flow 수집을 멈추고 다시 포그라운드로 돌아왔을때 수집을 재개한다.). 
==> collectAsStateWithLifecycle의 내부코드를 보면 minActiveState에 기본값으로 Lifecycle.State.STARTED를 사용하여 Lifecycle.State.STARTED를 사용하여 flow에서 값을 수집하거나 중지하기 때문에 가능함